### PR TITLE
ci(x86-v2): 加 dl/ccache 缓存并修复 Passwall feeds

### DIFF
--- a/.github/workflows/X86-v2.yml
+++ b/.github/workflows/X86-v2.yml
@@ -1,0 +1,149 @@
+#
+# Slim X86 build: Passwall + ZeroTier + LAN IP 10.1.1.99
+# Based on X86.yml, stripped of unrelated apps/drivers.
+#
+
+name: build artifact X86-v2
+
+on:
+  push:
+    branches:
+      - master
+      - cursor/x86-v2-slim-2fc1
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Get version
+        id: get_version
+        run: echo "VERSION=x86-v2-$(date +%Y%m%d)-$(git log --pretty=format:'%h' -1)" >> $GITHUB_OUTPUT
+
+      - name: Space cleanup
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          docker rmi `docker images -q` || true
+          sudo rm -rf /usr/share/dotnet /etc/mysql /etc/php /etc/apt/sources.list.d /usr/local/lib/android
+          sudo -E apt -y purge azure-cli* docker* ghc* zulu* llvm* firefox google* dotnet* powershell* openjdk* mysql* php* mongodb* snap* || true
+          sudo -E apt update
+          sudo -E apt full-upgrade -y
+          sudo -E apt -y install ack antlr3 asciidoc autoconf automake autopoint binutils bison build-essential bzip2 ccache clang cmake cpio curl device-tree-compiler flex gawk gcc-multilib g++-multilib gettext genisoimage git gperf haveged help2man intltool libc6-dev-i386 libelf-dev libfuse-dev libglib2.0-dev libgmp3-dev libltdl-dev libmpc-dev libmpfr-dev libncurses5-dev libncursesw5-dev libpython3-dev libreadline-dev libssl-dev libtool llvm lrzsz msmtp ninja-build p7zip p7zip-full patch pkgconf python3 python3-pyelftools python3-setuptools qemu-utils rsync scons squashfs-tools subversion swig texinfo uglifyjs upx-ucl unzip vim wget xmlto xxd zlib1g-dev
+          sudo -E apt -y autoremove --purge
+          sudo -E apt clean
+          df -h
+
+      - name: Update feeds
+        run: |
+          ./scripts/feeds update -a
+          ./scripts/feeds install -a
+
+      - name: Generate configuration file
+        run: |
+          rm -f ./.config*
+          touch ./.config
+          #
+          # ========================固件定制部分（精简版）========================
+          # 目标：Passwall + ZeroTier + 默认 LAN IP
+          #
+          cat >> .config <<EOF
+          CONFIG_TARGET_x86=y
+          CONFIG_TARGET_x86_64=y
+          CONFIG_TARGET_x86_64_DEVICE_generic=y
+          CONFIG_TARGET_IMAGES_GZIP=y
+          CONFIG_TARGET_ROOTFS_SQUASHFS=y
+          # CONFIG_VMDK_IMAGES is not set
+
+          # 基础工具
+          CONFIG_PACKAGE_ca-bundle=y
+          CONFIG_PACKAGE_curl=y
+          CONFIG_LIBCURL_COOKIES=y
+          CONFIG_LIBCURL_FILE=y
+          CONFIG_LIBCURL_FTP=y
+          CONFIG_LIBCURL_HTTP=y
+          CONFIG_LIBCURL_MBEDTLS=y
+          CONFIG_LIBCURL_NO_SMB="!"
+          CONFIG_LIBCURL_PROXY=y
+
+          # LuCI
+          CONFIG_PACKAGE_luci=y
+
+          # Passwall（feeds: passwall / passwall_packages）
+          CONFIG_PACKAGE_luci-app-passwall=y
+
+          # ZeroTier（需要 TUN）
+          CONFIG_PACKAGE_luci-app-zerotier=y
+          CONFIG_PACKAGE_zerotier=y
+          CONFIG_PACKAGE_kmod-tun=y
+          EOF
+          #
+          # ========================修改 LAN IP============================
+          mkdir -p files/etc/uci-defaults
+          cat > files/etc/uci-defaults/99-custom-ipaddr <<'EOF'
+          #!/bin/sh
+          uci set network.lan.ipaddr='10.1.1.99'
+          uci commit network
+          EOF
+          chmod +x files/etc/uci-defaults/99-custom-ipaddr
+          # ========================IP 修改结束=============================
+          #
+          sed -i 's/^[ \t]*//g' ./.config
+          make defconfig
+
+      - name: Make download
+        run: |
+          make download -j$(nproc) || make download -j1 V=s
+          find ./dl/ -size -1024c -exec rm -f {} \;
+          df -h
+
+      - name: Compile firmware
+        run: |
+          make -j$(nproc) || make -j1 V=s
+          echo "======================="
+          echo "Space usage:"
+          echo "======================="
+          df -h
+          echo "======================="
+          du -h --max-depth=1 ./ --exclude=build_dir --exclude=bin
+          du -h --max-depth=1 ./build_dir
+          du -h --max-depth=1 ./bin
+
+      - name: Prepare artifact
+        run: find ./bin/targets/ -type d -name "packages" | xargs rm -rf
+
+      - name: Debug Files
+        run: |
+          echo "Files in ./bin/targets/ (including subdirectories):"
+          ls -alR ./bin/targets/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.get_version.outputs.VERSION }}
+          path: |
+            ./bin/targets/**/*
+
+      - name: Release Firmware
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ./bin/targets/**/*
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
+          name: ${{ steps.get_version.outputs.VERSION }}
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/X86-v2.yml
+++ b/.github/workflows/X86-v2.yml
@@ -12,9 +12,17 @@ on:
       - cursor/x86-v2-slim-2fc1
   workflow_dispatch:
 
+concurrency:
+  group: x86-v2-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   actions: write
+
+env:
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 2G
 
 jobs:
 
@@ -27,7 +35,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: master
+          # Use the triggering branch so feeds.conf / workflow fixes apply.
+          ref: ${{ github.ref }}
 
       - name: Get version
         id: get_version
@@ -45,7 +54,25 @@ jobs:
           sudo -E apt -y install ack antlr3 asciidoc autoconf automake autopoint binutils bison build-essential bzip2 ccache clang cmake cpio curl device-tree-compiler flex gawk gcc-multilib g++-multilib gettext genisoimage git gperf haveged help2man intltool libc6-dev-i386 libelf-dev libfuse-dev libglib2.0-dev libgmp3-dev libltdl-dev libmpc-dev libmpfr-dev libncurses5-dev libncursesw5-dev libpython3-dev libreadline-dev libssl-dev libtool llvm lrzsz msmtp ninja-build p7zip p7zip-full patch pkgconf python3 python3-pyelftools python3-setuptools qemu-utils rsync scons squashfs-tools subversion swig texinfo uglifyjs upx-ucl unzip vim wget xmlto xxd zlib1g-dev
           sudo -E apt -y autoremove --purge
           sudo -E apt clean
+          ccache -M "$CCACHE_MAXSIZE" || true
           df -h
+
+      - name: Cache OpenWrt dl/
+        uses: actions/cache@v4
+        with:
+          path: dl
+          key: lede-dl-x86_64-${{ hashFiles('feeds.conf.default') }}
+          restore-keys: |
+            lede-dl-x86_64-
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: lede-ccache-x86_64-${{ hashFiles('feeds.conf.default', '.github/workflows/X86-v2.yml') }}-${{ github.sha }}
+          restore-keys: |
+            lede-ccache-x86_64-${{ hashFiles('feeds.conf.default', '.github/workflows/X86-v2.yml') }}-
+            lede-ccache-x86_64-
 
       - name: Update feeds
         run: |
@@ -61,12 +88,13 @@ jobs:
           # 目标：Passwall + ZeroTier + 默认 LAN IP
           #
           cat >> .config <<EOF
+          CONFIG_CCACHE=y
           CONFIG_TARGET_x86=y
           CONFIG_TARGET_x86_64=y
           CONFIG_TARGET_x86_64_DEVICE_generic=y
           CONFIG_TARGET_IMAGES_GZIP=y
           CONFIG_TARGET_ROOTFS_SQUASHFS=y
-          # CONFIG_VMDK_IMAGES is not set
+          CONFIG_VMDK_IMAGES=y
 
           # 基础工具
           CONFIG_PACKAGE_ca-bundle=y
@@ -113,6 +141,9 @@ jobs:
       - name: Compile firmware
         run: |
           make -j$(nproc) || make -j1 V=s
+          echo "======================="
+          echo "ccache stats:"
+          ccache -s || true
           echo "======================="
           echo "Space usage:"
           echo "======================="

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -10,5 +10,5 @@ src-git telephony https://github.com/coolsnowwolf/telephony.git
 #src-git targets https://github.com/openwrt/targets.git
 #src-git oldpackages http://git.openwrt.org/packages.git
 #src-link custom /usr/src/openwrt/custom-feed
-src-git passwall_packages https://github.com/xiaorouji/openwrt-passwall-packages.git;main
-src-git passwall https://github.com/xiaorouji/openwrt-passwall.git;main
+src-git passwall_packages https://github.com/Openwrt-Passwall/openwrt-passwall-packages.git;main
+src-git passwall https://github.com/Openwrt-Passwall/openwrt-passwall.git;main


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

为已合并的 `X86-v2` 补充构建缓存，并修复 Passwall feed 404。

## 变更

- `actions/cache`：`dl/` + `.ccache`（`CONFIG_CCACHE=y`）
- Passwall 源改为 `Openwrt-Passwall/*`（原 `xiaorouji/openwrt-passwall` 已 404）
- checkout 使用触发分支；`concurrency` 取消同分支旧任务
- 重新打开 `CONFIG_VMDK_IMAGES`（爱快）

## CI

推送后已在编：https://github.com/if8336/lede/actions/runs/32755116706

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0348e-b18a-7e6b-a65d-8f5c5f882fc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0348e-b18a-7e6b-a65d-8f5c5f882fc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

