### PR TITLE
fix(ci): 合并上游 commit 改用 GitHub 隐私邮箱

### DIFF
--- a/.github/workflows/mergeUpstream.yml
+++ b/.github/workflows/mergeUpstream.yml
@@ -28,8 +28,9 @@ jobs:
 
       - name: Set git identity
         run: |
-          git config --global user.email "yjw8886@gmail.com"
-          git config --global user.name "robot"
+          # Use GitHub noreply email — do not commit with a personal address.
+          git config --global user.email "38392415+if8336@users.noreply.github.com"
+          git config --global user.name "if8336"
           git config pull.rebase false
 
       - name: Load upstream commits


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

`mergeUpstream.yml` 里写死了 `yjw8886@gmail.com`，定时合并上游时会把真实邮箱写进 commit 元数据。

## 修改

改用 GitHub 隐私邮箱：`38392415+if8336@users.noreply.github.com`

## 说明

- **历史 commit** 里已有的 Gmail 不会自动消失；若要去掉需改历史（一般不必）。
- 建议在 GitHub → Settings → Emails 勾选 **Keep my email addresses private**，并关闭 **Block command line pushes that expose my email**（若要用 noreply 推送）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0348e-b18a-7e6b-a65d-8f5c5f882fc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0348e-b18a-7e6b-a65d-8f5c5f882fc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

